### PR TITLE
Use an on-the-fly sampleMap from the data to recover munged RNASeq2GeneNorm data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,16 @@
+## Changes in version 1.24.0 
+
+### Bug fixes and minor improvements
+
+* Create an on-the-fly `sampleMap` for `RNASeq2GeneNorm*` data version `2.1.1`.
+Data source has munged `colnames` and sample maps were not updated in the
+latest upload (#59, @LiNk-NY) 
+
 ## Changes in version 1.22.0 
 
 ### New features
 
-* Data version 2.1.1 is now availble. It contains updates to `RNASeq2GeneNorm`, 
+* Data version 2.1.1 is now availble. It contains updates to `RNASeq2GeneNorm*`, 
 and `RNASeq2Gene*`, as well as fixes to the curated subtypes in the `colData`
 for `OV` and `SKCM`.
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,14 @@
+## Taken from TCGAutils::TCGAbarcode
+.part_bcode <- function(barcodes) {
+    filler <- .uniqueDelim(barcodes)
+    barcodeMat <- do.call(rbind, strsplit(barcodes, filler))
+    apply(barcodeMat[, 1:3, drop = FALSE], 1L, paste, collapse = filler)
+}
+
+.uniqueDelim <- function (ids)  {
+    nonnum <- gsub("[[:alnum:]]", "", ids)
+    dels <- unique(unlist(strsplit(nonnum, "")))
+    if (!length(dels))
+        dels <- ""
+    dels
+}


### PR DESCRIPTION
To reproduce: 

``` r
curatedTCGAData::curatedTCGAData(c("ACC", "COAD"), "RNASeq2GeneNorm*", version = "2.1.1", dry.run = FALSE)
#> harmonizing input:
#>   removing 6094 sampleMap rows not in names(experiments)
#>   removing 79 sampleMap rows with 'colname' not in colnames of experiments
#>   removing 94 colData rownames not in sampleMap 'primary'
#> A MultiAssayExperiment object of 3 listed
#>  experiments with user-defined names and respective classes.
#>  Containing an ExperimentList class object of length 3:
#>  [1] COAD_RNASeq2GeneNorm_illuminaga-20160128: SummarizedExperiment with 20501 rows and 191 columns
#>  [2] COAD_RNASeq2GeneNorm_illuminahiseq-20160128: SummarizedExperiment with 20501 rows and 326 columns
#>  [3] ACC_RNASeq2GeneNorm-20160128: SummarizedExperiment with 17716 rows and 0 columns
#> Functionality:
#>  experiments() - obtain the ExperimentList instance
#>  colData() - the primary/phenotype DataFrame
#>  sampleMap() - the sample coordination DataFrame
#>  `$`, `[`, `[[` - extract colData columns, subset, or experiment
#>  *Format() - convert into a long or wide DataFrame
#>  assays() - convert ExperimentList to a SimpleList of matrices
#>  exportClass() - save data to flat files
```

<sup>Created on 2023-09-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

with fix:

``` r
curatedTCGAData::curatedTCGAData(c("ACC", "COAD"), "RNASeq2GeneNorm*", version = "2.1.1", dry.run = FALSE)
#> harmonizing input:
#>   removing 6094 sampleMap rows not in names(experiments)
#>   removing 15 colData rownames not in sampleMap 'primary'
#> A MultiAssayExperiment object of 4 listed
#>  experiments with user-defined names and respective classes.
#>  Containing an ExperimentList class object of length 4:
#>  [1] COAD_RNASeq2GeneNorm_illuminaga-20160128: SummarizedExperiment with 20501 rows and 191 columns
#>  [2] COAD_RNASeq2GeneNorm_illuminahiseq-20160128: SummarizedExperiment with 20501 rows and 326 columns
#>  [3] ACC_RNASeq2GeneNorm-20160128: SummarizedExperiment with 17716 rows and 79 columns
#>  [4] COAD_RNASeq2GeneNorm-20160128: SummarizedExperiment with 18025 rows and 498 columns
#> Functionality:
#>  experiments() - obtain the ExperimentList instance
#>  colData() - the primary/phenotype DataFrame
#>  sampleMap() - the sample coordination DataFrame
#>  `$`, `[`, `[[` - extract colData columns, subset, or experiment
#>  *Format() - convert into a long or wide DataFrame
#>  assays() - convert ExperimentList to a SimpleList of matrices
#>  exportClass() - save data to flat files
```

<sup>Created on 2023-09-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

