### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,13 +4,15 @@ Title: Curated Data from The Cancer Genome Atlas (TCGA) as
     MultiAssayExperiment Objects
 Version: 1.33.1
 Authors@R: c(
-    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu",
-        c("aut", "cre"), c(ORCID = "0000-0002-3242-0582")),
-    person("Levi", "Waldron", , "lwaldron.research@gmail.com", "ctb"),
-    person("Lucas", "Schiffer", , "schiffer.lucas@gmail.com", "ctb"),
-    person("Ludwig", "Geistlinger", , "ludwig.geistlinger@sph.cuny.edu", "ctb"),
-    person("Valerie", "Obenchain", , "valerie.obenchain@roswellpark.org","ctb"),
-    person("Martin", "Morgan", , "martin.morgan@roswellpark.org", "ctb")
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-3242-0582")),
+    person("Levi", "Waldron", , "lwaldron.research@gmail.com", role = "ctb"),
+    person("Lucas", "Schiffer", , "schiffer.lucas@gmail.com", role = "ctb"),
+    person("Ludwig", "Geistlinger", , "ludwig.geistlinger@sph.cuny.edu", role = "ctb"),
+    person("Valerie", "Obenchain", , "valerie.obenchain@roswellpark.org", role = "ctb"),
+    person("Martin", "Morgan", , "martin.morgan@roswellpark.org", role = "ctb"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
   )
 Description: This package provides publicly available data from The Cancer
     Genome Atlas (TCGA) as MultiAssayExperiment objects.


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23612179882](https://github.com/waldronlab/repo-audits/actions/runs/23612179882)).